### PR TITLE
fix: bust OG image cache for embeds

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { getAdjacentPosts, getAllPostSlugs, getPostBySlug, getPostSummaries, slu
 import { getRenderedPostContent } from "@/lib/rendered-post";
 
 export const dynamicParams = false;
+const OG_IMAGE_VERSION = "20260328-1";
 
 export async function generateStaticParams() {
   const slugs = await getAllPostSlugs();
@@ -38,7 +39,7 @@ export async function generateMetadata({
       type: "article",
       images: [
         {
-          url: `/blog/${post.slug}/opengraph-image`,
+          url: `/blog/${post.slug}/opengraph-image?v=${OG_IMAGE_VERSION}`,
           width: 1200,
           height: 630,
         },


### PR DESCRIPTION
**Changes:**

- Add a version query string to the blog post `og:image` URL
- Force social platforms to fetch the updated OG image instead of using the old cached asset

**Verification:**

- `npm run build`