### PR TITLE
[nightshift] lint-fix: fix TypeScript type errors in posts.test.ts

### DIFF
--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,7 +51,7 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<string, string>;
+    const cssVars = style as Record<"--post-accent" | "--font-post-mono", string>;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,8 +51,9 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
+    const cssVars = style as Record<"--post-accent" | "--font-post-mono", string>;
 
-    expect((style as Record<string, string>)["--post-accent"]).toBe("#ff00aa");
-    expect((style as Record<string, string>)["--font-post-mono"]).toContain("Spline Sans Mono");
+    expect(cssVars["--post-accent"]).toBe("#ff00aa");
+    expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");
   });
 });

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,9 +51,8 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<string, string>;
 
-    expect(cssVars["--post-accent"]).toBe("#ff00aa");
-    expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");
+    expect((style as Record<string, string>)["--post-accent"]).toBe("#ff00aa");
+    expect((style as Record<string, string>)["--font-post-mono"]).toContain("Spline Sans Mono");
   });
 });

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,7 +51,7 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<"--post-accent" | "--font-post-mono", string>;
+    const cssVars = style as Record<string, string>;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -52,7 +52,7 @@ describe("post parsing", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
 
-    expect(style["--post-accent" as string]).toBe("#ff00aa");
-    expect(style["--font-post-mono" as string]).toContain("Spline Sans Mono");
+    expect((style as Record<string, string>)["--post-accent"]).toBe("#ff00aa");
+    expect((style as Record<string, string>)["--font-post-mono"]).toContain("Spline Sans Mono");
   });
 });


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** lint-fix
**Category:** pr
**Changes:**

Fixed 2 TypeScript type errors in `src/lib/posts.test.ts`:

- Line 55: Replace `style["--post-accent" as string]` with `(style as Record<string, string>)["--post-accent"]` — CSS custom properties need a proper Record type assertion instead of `as string` on the key.
- Line 56: Same fix for `--font-post-mono` key.

**Verification:**
- `tsc --noEmit` passes with 0 errors (was 4 errors)
- All 8 tests pass (`vitest run`)
- No new dependencies added
- No formatter changes

Merge if useful, close if not.