### PR TITLE
[nightshift] lint-fix: fix CSSProperties indexing in test

### DIFF
--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,7 +51,7 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<string, string>;
+    const cssVars = style as Record<string, string | undefined>;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,7 +51,7 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<string, string>;
+    const cssVars = style as Record<"--post-accent" | "--font-post-mono", string>;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -50,9 +50,9 @@ describe("post parsing", () => {
 
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
-    const style = getThemeStyle(parsed.theme);
+    const style = getThemeStyle(parsed.theme) as Record<string, string>;
 
-    expect(style["--post-accent" as string]).toBe("#ff00aa");
-    expect(style["--font-post-mono" as string]).toContain("Spline Sans Mono");
+    expect(style["--post-accent"]).toBe("#ff00aa");
+    expect(style["--font-post-mono"]).toContain("Spline Sans Mono");
   });
 });

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,7 +51,8 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<string, string>;
+    type ThemeCssVars = Record<`--${string}`, string>;
+    const cssVars = style as ThemeCssVars;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,8 +51,7 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    type ThemeCssVars = Record<`--${string}`, string>;
-    const cssVars = style as ThemeCssVars;
+    const cssVars = style as Record<string, string>;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,7 +51,7 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<"--post-accent" | "--font-post-mono", string>;
+    const cssVars = style as Record<string, string>;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -50,9 +50,10 @@ describe("post parsing", () => {
 
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
-    const style = getThemeStyle(parsed.theme) as Record<string, string>;
+    const style = getThemeStyle(parsed.theme);
+    const cssVars = style as Record<"--post-accent" | "--font-post-mono", string>;
 
-    expect(style["--post-accent"]).toBe("#ff00aa");
-    expect(style["--font-post-mono"]).toContain("Spline Sans Mono");
+    expect(cssVars["--post-accent"]).toBe("#ff00aa");
+    expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");
   });
 });

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,7 +51,7 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<string, string>;
+    const cssVars = style as Record<`--${string}`, string>;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -51,7 +51,7 @@ describe("post parsing", () => {
   it("exposes post theme CSS variables", () => {
     const parsed = parseEditablePost(source);
     const style = getThemeStyle(parsed.theme);
-    const cssVars = style as Record<`--${string}`, string>;
+    const cssVars = style as Record<string, string>;
 
     expect(cssVars["--post-accent"]).toBe("#ff00aa");
     expect(cssVars["--font-post-mono"]).toContain("Spline Sans Mono");


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** lint-fix
**Category:** PR
**Changes:** Fix TypeScript error in `posts.test.ts` where custom CSS property access (`style["--post-accent" as string]`) caused `TS7053` because `CSSProperties` lacks a string index signature. Cast to `Record<string, string>` before indexing.

ESLint was already clean (0 errors). This was the only type error found by `tsc --noEmit`.

All 12 tests pass.

Merge if useful, close if not.